### PR TITLE
Add deep SpecAugment via hooks

### DIFF
--- a/configs/large-sg-corpus-mc.yaml
+++ b/configs/large-sg-corpus-mc.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/large-srg-real-sg-corpus.yaml
+++ b/configs/large-srg-real-sg-corpus.yaml
@@ -49,6 +49,10 @@ augmentation:
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment:
     apply: False
     lpf: # Low pass filter

--- a/configs/large-v3-sg-corpus-mc.yaml
+++ b/configs/large-v3-sg-corpus-mc.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/sg_corp_train_neg_overlap_no_speaker_ret.yaml
+++ b/configs/sg_corp_train_neg_overlap_no_speaker_ret.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/sg_corp_train_no_overlap_no_speaker_ret.yaml
+++ b/configs/sg_corp_train_no_overlap_no_speaker_ret.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/sg_corp_train_no_overlap_speaker_ret.yaml
+++ b/configs/sg_corp_train_no_overlap_speaker_ret.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/sg_corp_train_overlap_no_speaker_ret.yaml
+++ b/configs/sg_corp_train_overlap_no_speaker_ret.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/whisper_paper_100_data.yaml
+++ b/configs/whisper_paper_100_data.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/whisper_paper_20_data.yaml
+++ b/configs/whisper_paper_20_data.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/whisper_paper_40_data.yaml
+++ b/configs/whisper_paper_40_data.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/whisper_paper_60_data.yaml
+++ b/configs/whisper_paper_60_data.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter

--- a/configs/whisper_paper_80_data.yaml
+++ b/configs/whisper_paper_80_data.yaml
@@ -49,6 +49,10 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  deep_spec_augment:
+    apply: False
+    time_mask_param: 20
+    freq_mask_param: 10
   audio_augment: # Audio augmentations by reducing audio quality (white noise, high-pass filter, and low-pass filter).
     apply: False
     lpf: # Low pass filter


### PR DESCRIPTION
## Summary
- register hooks in the encoder to apply SpecAugment after selected layers
- expose configuration for deep SpecAugment and insert defaults in all config files
- use the new configuration inside the finetuning script

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_683613dab62c832097a50846fe4ef114