### PR TITLE
Add extreme freq specaugment

### DIFF
--- a/configs/whisper_paper_100_data.yaml
+++ b/configs/whisper_paper_100_data.yaml
@@ -48,6 +48,9 @@ augmentation: # Data augmentations, see the whisper paper for more details
     time_mask_param: 100
     p: 1.0
     freq_mask_param: 27
+    freq_mask_param_extreme: 10
+    low_freq_range: 20
+    high_freq_range: 20
     time_warp_w: 80
   deep_spec_augment:
     apply: False

--- a/configs/whisper_paper_100_data.yaml
+++ b/configs/whisper_paper_100_data.yaml
@@ -48,10 +48,12 @@ augmentation: # Data augmentations, see the whisper paper for more details
     time_mask_param: 100
     p: 1.0
     freq_mask_param: 27
-    freq_mask_param_extreme: 10
+    time_warp_w: 80
+  extremes_spec_augment:
+    apply: False
+    freq_mask_param: 10
     low_freq_range: 20
     high_freq_range: 20
-    time_warp_w: 80
   deep_spec_augment:
     apply: False
     time_mask_param: 20

--- a/src/whisper_finetune/data/data_loader.py
+++ b/src/whisper_finetune/data/data_loader.py
@@ -222,7 +222,7 @@ class AudioDataset(Dataset):
             mel = self.time_masking(mel)
             mel = self.freq_masking(mel)
 
-        if self.extremes_spec_augment and self.extreme_freq_masking is not None:
+        if self.extreme_freq_masking:
             mel = self.extreme_freq_masking(mel)
 
         return mel

--- a/src/whisper_finetune/scripts/finetune.py
+++ b/src/whisper_finetune/scripts/finetune.py
@@ -208,6 +208,8 @@ def main(config):
     whisper_model.to("cuda")
 
     if config["augmentation"].get("deep_spec_augment", {}).get("apply", False):
+        # SpecAugment applied inside the encoder as in SpecAugment++
+        # https://arxiv.org/abs/2103.16858
         dconf = config["augmentation"]["deep_spec_augment"]
         register_deep_spec_augment_hooks(
             whisper_model,
@@ -254,6 +256,8 @@ def main(config):
         num_workers=min(os.cpu_count(), 8),
         spec_augment=config["augmentation"]["spec_augment"]["apply"],
         spec_augment_params=config["augmentation"]["spec_augment"],
+        extremes_spec_augment=config["augmentation"]["extremes_spec_augment"]["apply"],
+        extremes_spec_augment_params=config["augmentation"]["extremes_spec_augment"],
         audio_aug=config["augmentation"]["audio_augment"]["apply"],
         audio_augment_params=config["augmentation"]["audio_augment"],
     )
@@ -267,6 +271,8 @@ def main(config):
         no_timestamps_rate=0,
         num_workers=min(os.cpu_count(), 8),
         spec_augment=False,
+        extremes_spec_augment=False,
+        extremes_spec_augment_params=None,
         audio_aug=False,
     )
 


### PR DESCRIPTION
## Summary
- add `ExtremeFrequencyMasking` transform to mask only low/high mel bins
- integrate the new transform in `AudioDataset`
- expose parameters in `whisper_paper_100_data.yaml`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68400794ac28832089bbe51e114cb341