### PR TITLE
Add extreme frequency specaugment

### DIFF
--- a/configs/whisper_paper_100_data.yaml
+++ b/configs/whisper_paper_100_data.yaml
@@ -49,6 +49,11 @@ augmentation: # Data augmentations, see the whisper paper for more details
     p: 1.0
     freq_mask_param: 27
     time_warp_w: 80
+  extremes_spec_augment:
+    apply: False
+    freq_mask_param: 10
+    low_freq_range: 20
+    high_freq_range: 20
   deep_spec_augment:
     apply: False
     time_mask_param: 20

--- a/src/whisper_finetune/scripts/finetune.py
+++ b/src/whisper_finetune/scripts/finetune.py
@@ -208,6 +208,8 @@ def main(config):
     whisper_model.to("cuda")
 
     if config["augmentation"].get("deep_spec_augment", {}).get("apply", False):
+        # SpecAugment applied inside the encoder as in SpecAugment++
+        # https://arxiv.org/abs/2103.16858
         dconf = config["augmentation"]["deep_spec_augment"]
         register_deep_spec_augment_hooks(
             whisper_model,
@@ -254,6 +256,8 @@ def main(config):
         num_workers=min(os.cpu_count(), 8),
         spec_augment=config["augmentation"]["spec_augment"]["apply"],
         spec_augment_params=config["augmentation"]["spec_augment"],
+        extremes_spec_augment=config["augmentation"]["extremes_spec_augment"]["apply"],
+        extremes_spec_augment_params=config["augmentation"]["extremes_spec_augment"],
         audio_aug=config["augmentation"]["audio_augment"]["apply"],
         audio_augment_params=config["augmentation"]["audio_augment"],
     )
@@ -267,6 +271,8 @@ def main(config):
         no_timestamps_rate=0,
         num_workers=min(os.cpu_count(), 8),
         spec_augment=False,
+        extremes_spec_augment=False,
+        extremes_spec_augment_params=None,
         audio_aug=False,
     )
 


### PR DESCRIPTION
## Summary
- introduce optional extreme frequency masking augment class
- integrate extreme frequency specaugment in dataset and config
- comment specaugment++ reference when applying deep spec augment
- address review comment on augmentation check

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68400794ac28832089bbe51e114cb341